### PR TITLE
feat: LLM翻译

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 
 - 灵活的配置项，支持修改代理、配色等
 - 支持`-s`[朗读单词](#读音功能experimental) 📢
+- 支持使用LLM作为翻译后端 🤖
 - 其他小功能（[详见下文](#-用法)）：
     - 支持纯英文模式，只显示英译/英文例句
 
@@ -228,6 +229,9 @@ enable_emoji = true
 # 是否开启频率提醒：本月第X次查询xxx
 freq_alert = false
 
+# 翻译来源，目前可选 youdao / llm
+source = "youdao"
+
 # 日志配置
 [logging]
   # 开启日志记录（程序异常时会记录关键信息，不建议关闭）
@@ -236,6 +240,15 @@ freq_alert = false
   path = ""
   # 日志级别，支持：DEBUG/INFO/WARN/PANIC/FATAL
   level = "WARN"
+
+# 对于LLM翻译的配置，设置 source = "llm" 时必需
+[llm]
+  # 接入api服务的baseurl，使用时会在后面追加"/chat/completions"
+  base_url = "https://api.deepseek.com"
+  # 使用的模型名称
+  model = "deepseek-v4-flash"
+  # api key
+  api_key = "sk-***"
 ```
 
 ### 更多特性

--- a/cmd/kd/kd.go
+++ b/cmd/kd/kd.go
@@ -359,7 +359,7 @@ func main() {
 
 				qstr := strings.Join(cCtx.Args().Slice(), " ")
 
-				if r, err := internal.Query(qstr, cCtx.Bool("nocache"), cCtx.Bool("text")); err == nil {
+				if r, err := internal.Query(qstr, cCtx.Bool("nocache"), cCtx.Bool("text"), cfg.Source); err == nil {
 					if cCtx.Bool("json") {
 						if j, jsonErr := json.Marshal(r); jsonErr == nil {
 							fmt.Println(string(j))

--- a/config/config.go
+++ b/config/config.go
@@ -27,10 +27,17 @@ type LoggerConfig struct {
 	RedirectToStream bool   `default:"false" toml:"redirect_to_stream"`
 }
 
+type LLMConfig struct {
+	BaseUrl string `toml:"base_url"`
+	Model   string `toml:"model"`
+	ApiKey  string `toml:"api_key"`
+}
+
 type Config struct {
-	// FIXME (k): <2025-06-12 01:08> 
+	// FIXME (k): <2025-06-12 01:08>
 	Debug bool `default:"false" toml:"debug"`
 
+	Source       string `toml:"source" default:"youdao"`
 	// Modules      []string
 	EnableEmoji  bool   `default:"true" toml:"enable_emoji"`
 	Paging       bool   `default:"true" toml:"paging"`
@@ -44,6 +51,8 @@ type Config struct {
 	// MaxCached    uint   `default:"10000" toml:"max_cached"`
 
 	Logging LoggerConfig `toml:"logging"`
+
+	LLM LLMConfig `toml:"llm"`
 
 	FileExists bool  `toml:"-"`
 	ModTime    int64 `toml:"-"`

--- a/internal/client.go
+++ b/internal/client.go
@@ -64,7 +64,7 @@ var (
 	longRegex  = regexp.MustCompile("^[a-zA-Z0-9\u4e00-\u9fa5\u3000-\u303F]")
 )
 
-func Query(query string, noCache bool, longText bool) (r *model.Result, err error) {
+func Query(query string, noCache bool, longText bool, source string) (r *model.Result, err error) {
 	// TODO (k): <2024-01-02> regexp
 	query = str.Simplify(query)
 	if !longText {
@@ -120,7 +120,7 @@ func Query(query string, noCache bool, longText bool) (r *model.Result, err erro
 	}
 
 	if <-daemonRunning {
-		err = QueryDaemon(r)
+		err = q.QueryDaemon(fmt.Sprintf("localhost:%d", run.SERVER_PORT), r, source)
 		if err == nil && r.Found && inNotFound {
 			go cache.RemoveNotFound(r.Query)
 		}
@@ -129,10 +129,4 @@ func Query(query string, noCache bool, longText bool) (r *model.Result, err erro
 	}
 
 	return r, err
-}
-
-func QueryDaemon(r *model.Result) error {
-	addr := fmt.Sprintf("localhost:%d", run.SERVER_PORT)
-	err := q.QueryDaemon(addr, r)
-	return err
 }

--- a/internal/query/online.go
+++ b/internal/query/online.go
@@ -1,7 +1,9 @@
 package query
 
 import (
+	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,6 +24,7 @@ import (
 
 var ydCliLegacy = &http.Client{Timeout: 5 * time.Second}
 var ydCli = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, Timeout: 5 * time.Second}
+var llm_client = &http.Client{Timeout: 30 * time.Second}
 
 func requestYoudao(r *model.Result) (body []byte, err error) {
 	var req *http.Request
@@ -130,6 +133,130 @@ func FetchOnline(r *model.Result) (err error) {
 
 	r.Found = true
 	go cache.UpdateQueryCache(r)
+	return
+}
+
+const LLM_PROMPT_TEXT = "请将用户输入的内容翻译为中文，除了翻译结果以外不要带任何解释或多余内容"
+const LLM_PROMPT_WORD = `请将用户输入的内容翻译为中文，输出格式必须严格遵守要求，不得包含多余内容：
+第一行为用户想要查询的词的原文（注意大小写，例如monday应该变为Monday）
+第二行为发音音标，如果英式美式发音不同，以/分隔，英式在前。除了中间的分隔符外不能有多余的/。例(please): pliːz/pliz
+第三行及之后每行为单词释义，每行一种词性（n./adj./vt./vi./etc），如果两个相同词性的释义意义差别大，可以拆为多条
+如果无法确定发音，此行留空；如果发音和意义都无法确定，第三行写Not found`
+
+func FetchLLM(r *model.Result) (err error) {
+	// 检查配置情况
+	cfg := config.Cfg
+	if cfg.LLM.Model == "" || cfg.LLM.BaseUrl == "" || cfg.LLM.ApiKey == "" {
+		err_msg := "未配置"
+		if cfg.LLM.BaseUrl == "" {
+			err_msg += " llm.base_url"
+		}
+		if cfg.LLM.Model == "" {
+			err_msg += " llm.model"
+		}
+		if cfg.LLM.ApiKey == "" {
+			err_msg += " llm.api_key"
+		}
+		return fmt.Errorf(err_msg)
+	}
+	url := cfg.LLM.BaseUrl + "/chat/completions"
+	model := cfg.LLM.Model
+	var prompt string
+	if r.IsLongText {
+		prompt = LLM_PROMPT_TEXT
+	} else {
+		prompt = LLM_PROMPT_WORD
+	}
+	// 格式化消息体
+	body := map[string]any{
+		"model":       model,
+		"stream":      false,
+		"temperature": 0.2,
+		"messages": []map[string]string{
+			{"role": "system", "content": prompt},
+			{"role": "user", "content": r.Query},
+		},
+	}
+	jsonData, err := json.Marshal(body)
+	if err != nil {
+		zap.S().Errorf("Failed to build request body: %s", err)
+		return
+	}
+	request, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		zap.S().Errorf("Failed to create request: %s", err)
+		return
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cfg.LLM.ApiKey))
+
+	response, err := llm_client.Do(request)
+	if err != nil {
+		zap.S().Errorf("[http] Failed to request: %s", err)
+		return
+	}
+	defer response.Body.Close()
+
+	// if response.StatusCode != http.StatusOK {
+	// 	zap.S().Errorf("[http] Status: %s", response.Status)
+	// }
+	respBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		zap.S().Errorf("[http] Failed to read response: %s", err)
+		return
+	}
+	// 提取内容
+	var llm_res struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err = json.Unmarshal(respBody, &llm_res); err != nil || len(llm_res.Choices) == 0 {
+		var llm_err struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if e := json.Unmarshal(respBody, &llm_err); e == nil {
+			zap.S().Errorf("Api response error: %s", llm_err.Error.Message)
+			err = fmt.Errorf("LLM调用错误: %s", llm_err.Error.Message)
+		} else {
+			zap.S().Errorf("Api response error")
+			err = fmt.Errorf("LLM请求返回了无法解析的数据: %s", string(respBody))
+		}
+		return
+	}
+	zap.S().Debugf("Raw LLM response: %s\n", llm_res.Choices[0].Message.Content)
+	// 解析输出
+	llm_output := llm_res.Choices[0].Message.Content
+	if r.IsLongText {
+		r.Keyword = r.Query
+		r.MachineTrans = llm_output
+	} else {
+		lines := strings.Split(llm_output, "\n")
+		for i, s := range lines {
+			s = strings.TrimSpace(s)
+			switch i {
+			case 0:
+				r.Keyword = s
+			case 1:
+				if len(s) != 0 {
+					prons := strings.Split(s, "/")
+					if len(prons) == 1 {
+						r.Pronounce = map[string]string{"英": prons[0], "美": prons[0]}
+					}
+					if len(prons) == 2 {
+						r.Pronounce = map[string]string{"英": prons[0], "美": prons[1]}
+					}
+				}
+			default:
+				r.Paraphrase = append(r.Paraphrase, s)
+			}
+		}
+	}
+	r.Found = true
 	return
 }
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -38,13 +38,13 @@ func FetchCached(r *model.Result) (err error) {
 	return
 }
 
-func QueryDaemon(addr string, r *model.Result) error {
+func QueryDaemon(addr string, r *model.Result, querySource string) error {
 	conn, err := net.Dial("tcp", addr)
 	if err != nil {
 		d.EchoFatal("与守护进程通信失败，请尝试执行`kd --daemon`，如果无法解决问题，请提交issue并上传日志")
 		return err
 	}
-	q := model.TCPQuery{Action: "query", B: r.BaseResult}
+	q := model.TCPQuery{Action: "query-" + querySource, B: r.BaseResult}
 	var j []byte
 	j, err = json.Marshal(q)
 	if err != nil {

--- a/internal/server.go
+++ b/internal/server.go
@@ -83,14 +83,22 @@ func handleClient(conn net.Conn) {
 	r.Initialize()
 
 	var reply []byte
-	if err = query.FetchOnline(r); err != nil {
-		zap.S().Warnf("Failed to run FetchOnline with %+v. Error: %s", r, err)
+	switch q.Action {
+	case "query-youdao":
+		err = query.FetchOnline(r)
+	case "query-llm":
+		err = query.FetchLLM(r)
+	default:
+		err = fmt.Errorf("未知的操作类型: %s", q.Action)
+	}
+	if err != nil {
+		zap.S().Warnf("Failed to fetch with %+v. Error: %s", r, err)
 		var errmsg string
 		if strings.Contains(err.Error(), "proxyconnect") {
 			// errmsg = fmt.Sprintf("代理连接异常（%q）", err.Error())
 			errmsg = "代理连接异常，请求失败：" + err.Error()
 		} else {
-			errmsg = fmt.Sprintf("在线查询失败（%v）", err.Error())
+			errmsg = fmt.Sprintf("查询失败（%v）", err.Error())
 		}
 		reply, _ = json.Marshal(model.DaemonResponse{Error: errmsg})
 	} else {


### PR DESCRIPTION
目前是在 internal/query/online.go 里面添加了使用 llm 查词的函数。

目前不确定怎么识别用户请求llm翻译（看了下调用链感觉不好塞），所以出于调试目的把默认的查词方案强制设置为llm。

以及目前是直接将 llm 的翻译结果作为输出，后续应该还能改成类似通常查词的结构（用法，例句等）。

想征求一下您的意见。