### PR TITLE
feat: add support for querying all `query` from tables ch and en

### DIFF
--- a/cmd/kd/kd.go
+++ b/cmd/kd/kd.go
@@ -59,6 +59,8 @@ var um = map[string]string{
 	"edit-config":     "edit configuration file with the default editor 用默认编辑器打开配置文件",
 	"status":          "show running status 展示运行信息",
 	"log-to-stream":   "redirect logging output to stdout&stderr (for debugging or server mode)",
+	"all-en":          "list all English words 列出所有英文单词",
+	"all-ch":          "list all Chinese words 列出所有中文词条",
 }
 
 //  -----------------------------------------------------------------------------
@@ -230,6 +232,43 @@ func flagStatus(*cli.Context, bool) error {
 	return err
 }
 
+func listAllLocalQueries(isEN bool) error {
+	tableName := "ch"
+	if isEN {
+		tableName = "en"
+	}
+
+	words, err := cache.GetCachedWordList(isEN)
+	if err != nil {
+		zap.S().Errorf("Failed to read all %s queries: %s", tableName, err)
+		d.EchoError(fmt.Sprintf("读取本地缓存失败: %s", err))
+		return err
+	}
+
+	if len(words) == 0 {
+		fmt.Fprintln(os.Stderr, d.Yellow("本地暂无任何缓存数据。"))
+		return nil
+	}
+
+	var sb strings.Builder
+	for _, word := range words {
+		fmt.Fprintf(&sb, "%s\n", word)
+	}
+
+	if err = pkg.OutputResult(sb.String(), config.Cfg.Paging, config.Cfg.PagerCommand); err != nil {
+		d.EchoFatal(err.Error())
+	}
+	return nil
+}
+
+func flagAllEn(*cli.Context, bool) error {
+	return listAllLocalQueries(true)
+}
+
+func flagAllCh(*cli.Context, bool) error {
+	return listAllLocalQueries(false)
+}
+
 func checkAndNoticeUpdate() {
 	if ltag := update.GetCachedLatestTag(); ltag != "" {
 		if update.CompareVersions(ltag, VERSION) == 1 {
@@ -326,6 +365,8 @@ func main() {
 			&cli.BoolFlag{Name: "edit-config", DisableDefaultText: true, Action: flagEditConfig, Usage: um["edit-config"]},
 			&cli.BoolFlag{Name: "status", DisableDefaultText: true, Hidden: true, Action: flagStatus, Usage: um["status"]},
 			&cli.BoolFlag{Name: "log-to-stream", DisableDefaultText: true, Hidden: true, Usage: um["log-to-stream"]},
+			&cli.BoolFlag{Name: "all-en", DisableDefaultText: true, Action: flagAllEn, Usage: um["all-en"]},
+			&cli.BoolFlag{Name: "all-ch", DisableDefaultText: true, Action: flagAllCh, Usage: um["all-ch"]},
 		},
 		Action: func(cCtx *cli.Context) error {
 			// 这里BoolFlag都当subcommand用
@@ -333,7 +374,7 @@ func main() {
 				defer checkAndNoticeUpdate()
 			}
 
-			if pkg.HasAnyFlag("init", "server", "daemon", "stop", "restart", "update", "generate-config", "edit-config", "status") {
+			if pkg.HasAnyFlag("init", "server", "daemon", "stop", "restart", "update", "generate-config", "edit-config", "status", "all-en", "all-ch") {
 				return nil
 			}
 

--- a/internal/cache/database.go
+++ b/internal/cache/database.go
@@ -94,3 +94,39 @@ func saveCachedRow(query string, isEN bool, detail []byte) error {
 	}
 	return err
 }
+
+func GetCachedWordList(isEN bool) ([]string, error) {
+	var table string
+	if isEN {
+		table = "en"
+	} else {
+		table = "ch"
+	}
+
+	sqlStr := fmt.Sprintf("SELECT query FROM %s ORDER BY query ASC", table)
+
+	rows, err := LiteDB.Query(sqlStr)
+	if err != nil {
+		zap.S().Errorf("Failed to query all words from %s: %v", table, err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	var words []string
+	for rows.Next() {
+		var word string
+		if err := rows.Scan(&word); err != nil {
+			zap.S().Warnf("Failed to scan row from %s: %v", table, err)
+			continue
+		}
+		words = append(words, word)
+	}
+
+	if err = rows.Err(); err != nil {
+		zap.S().Errorf("Row iteration error for %s: %v", table, err)
+		return nil, err
+	}
+
+	zap.S().Debugf("Got %d cached words from %s", len(words), table)
+	return words, nil
+}


### PR DESCRIPTION
增加两个可以获取所有query的参数`--all-en`和`--all-ch`，可以用`./kd (./kd --all-en | fzf --preview "kd {}")`来实现fzf支持，无需调用sqlite3 ~/.cache/kdcache/kd_data.db进行手动select，同时可以在fish中通过`complete -c kd -f -a "(kd --all-en)"`来实现单词补全