### PR TITLE
feat: support root user via KD_ALLOW_ROOT env var (#51)

### DIFF
--- a/cmd/kd/kd.go
+++ b/cmd/kd/kd.go
@@ -245,8 +245,10 @@ func checkAndNoticeUpdate() {
 func basicCheck() {
 	if runtime.GOOS != "windows" {
 		if u, _ := user.Current(); u.Username == "root" {
-			d.EchoWrong("不支持Root用户")
-			os.Exit(1)
+			if os.Getenv("KD_ALLOW_ROOT") != "1" {
+				d.EchoWrong("不支持Root用户。如确认需要，请设置环境变量 KD_ALLOW_ROOT=1")
+				os.Exit(1)
+			}
 		}
 	}
 


### PR DESCRIPTION
### 背景

Issue #51：用户在 Linux VPS 上以 root 运行 kd 时， 直接拦截报错并退出，无绕行方式。

### 改动

 — 修改 root 检测逻辑：

- 未设置  → 保持原行为（报错退出，提示用户设置环境变量绕行）
- 已设置  → 静默放行，无多余警告

### 使用方式

```bash
# root 用户运行
export KD_ALLOW_ROOT=1
kd <query>
```

### 说明

没用 CLI flag 因为  在  之前执行，flag 尚未解析。环境变量是最小侵入方案。

Closes #51